### PR TITLE
Drop vendor prefixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ before_script:
   yarn run build
 script:
   yarn test
+addons:
+  chrome: stable

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "rollup -c -w -m inline",
     "build": "rollup -c && rollup -c rollup.config.min.js",
-    "test": "cypress run",
+    "test": "cypress run --browser chrome",
     "test:open": "cypress open",
     "docs": "docsify serve ./docs"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,12 @@
-export const webkitPrefix = 'WebkitAppearance' in document.documentElement.style
-  ? '-webkit-'
-  : ''
-
 export const cursor = {
   default: 'auto',
-  zoomIn: `${webkitPrefix}zoom-in`,
-  zoomOut: `${webkitPrefix}zoom-out`,
-  grab: `${webkitPrefix}grab`,
+  zoomIn: 'zoom-in',
+  zoomOut: 'zoom-out',
+  grab: 'grab',
   move: 'move'
 }
 
-export function listen (el, event, handler, add = true) {
+export function listen(el, event, handler, add = true) {
   const options = { passive: false }
 
   if (add) {
@@ -20,11 +16,11 @@ export function listen (el, event, handler, add = true) {
   }
 }
 
-export function loadImage (src, cb) {
+export function loadImage(src, cb) {
   if (src) {
     const img = new Image()
 
-    img.onload = function onImageLoad () {
+    img.onload = function onImageLoad() {
       if (cb) cb(img)
     }
 
@@ -32,7 +28,7 @@ export function loadImage (src, cb) {
   }
 }
 
-export function getOriginalSource (el) {
+export function getOriginalSource(el) {
   if (el.dataset.original) {
     return el.dataset.original
   } else if (el.parentNode.tagName === 'A') {
@@ -42,7 +38,7 @@ export function getOriginalSource (el) {
   }
 }
 
-export function setStyle (el, styles, remember) {
+export function setStyle(el, styles, remember) {
   checkTrans(styles)
 
   let s = el.style
@@ -59,18 +55,22 @@ export function setStyle (el, styles, remember) {
   return original
 }
 
-export function bindAll (_this, that) {
+export function bindAll(_this, that) {
   const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(_this))
-  methods.forEach(function bindOne (method) {
+  methods.forEach(function bindOne(method) {
     _this[method] = _this[method].bind(that)
   })
 }
 
-const trans = sniffTransition(document.createElement('div'))
-export const transformCssProp = trans.transformCssProp
-export const transEndEvent = trans.transEndEvent
+const trans = {
+  transitionProp: 'transition',
+  transEndEvent: 'transitionend',
+  transformProp: 'transform',
+  transformCssProp: 'transform'
+}
+export const { transformCssProp, transEndEvent } = trans
 
-function checkTrans (styles) {
+function checkTrans(styles) {
   const { transitionProp, transformProp } = trans
 
   if (styles.transition) {
@@ -84,33 +84,4 @@ function checkTrans (styles) {
     delete styles.transform
     styles[transformProp] = value
   }
-}
-
-function sniffTransition (el) {
-  let res = {}
-  const trans = ['webkitTransition', 'transition', 'mozTransition']
-  const tform = ['webkitTransform', 'transform', 'mozTransform']
-  const end = {
-    transition: 'transitionend',
-    mozTransition: 'transitionend',
-    webkitTransition: 'webkitTransitionEnd'
-  }
-
-  trans.some(function hasTransition (prop) {
-    if (el.style[prop] !== undefined) {
-      res.transitionProp = prop
-      res.transEndEvent = end[prop]
-      return true
-    }
-  })
-
-  tform.some(function hasTransform (prop) {
-    if (el.style[prop] !== undefined) {
-      res.transformProp = prop
-      res.transformCssProp = prop.replace(/(.*)Transform/, '-$1-transform')
-      return true
-    }
-  })
-
-  return res
 }


### PR DESCRIPTION
Removes `moz` and `webkit` prefixes for cursor icons, transitions, and transforms. Fixes #116 