### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Image zoom that makes sense.">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
 </head>
 
 <body>
@@ -25,7 +30,10 @@
       search: 'auto'
     }
   </script>
-
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
+  </script>
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
   <script src="https://unpkg.com/docsify-copy-code@2"></script>
 </body>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79609494-7a55e500-8114-11ea-89d0-8b12465482a2.png)

After

![image](https://user-images.githubusercontent.com/10001746/79609558-96f21d00-8114-11ea-8638-0528e09efc39.png)

**Dark Mode :**

![image](https://user-images.githubusercontent.com/10001746/79609600-a7a29300-8114-11ea-83a0-e950539a999f.png)


